### PR TITLE
set `useNameForId` to `false`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,6 +11,7 @@ module.exports = {
       options: {
         spaceId: "spaceID",
         accessToken: "accessToken",
+        useNameForId: false,
       },
     },
   ],


### PR DESCRIPTION
set `useNameForId` to `false` to fix the problem with emojis